### PR TITLE
🚑 Change Contribution count method

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -501,9 +501,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let dateForWeekend = dateFormatter.date(from: date)
         guard let weekend = dateForWeekend?.dayOfWeek() else { return ContributeData(count: 0, weekend: "", date: "")}
-        guard let count = Int(attr.get(key: ParseKeys.contributionCount)) else { return ContributeData(count: 0, weekend: "", date: "")}
         
-        return ContributeData(count: count, weekend: weekend, date: date)
+        do {
+            let countString = try selectCountFrom(str: ele.text())
+            guard let count = Int(countString) else { return ContributeData(count: 0, weekend: "", date: "") }
+            return ContributeData(count: count, weekend: weekend, date: date)
+        } catch {
+            return ContributeData(count: 0, weekend: "", date: "")
+        }
+    }
+    
+    private func selectCountFrom(str: String) -> String {
+        let pattern = "\\d+"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return "0"
+        }
+        let range = NSRange(location: 0, length: str.utf16.count)
+        if let match = regex.firstMatch(in: str, options: [], range: range) {
+            let value = (str as NSString).substring(with: match.range)
+            return value
+        }
+        return "0"
     }
     
     private func parseHtmltoData(html: String) -> [ContributeData] {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -503,25 +503,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard let weekend = dateForWeekend?.dayOfWeek() else { return ContributeData(count: 0, weekend: "", date: "")}
         
         do {
-            let countString = try selectCountFrom(str: ele.text())
-            guard let count = Int(countString) else { return ContributeData(count: 0, weekend: "", date: "") }
-            return ContributeData(count: count, weekend: weekend, date: date)
+            if let count = try selectCountFrom(sentence: ele.text()) {
+                return ContributeData(count: count, weekend: weekend, date: date)
+            } else {
+                return ContributeData(count: 0, weekend: "", date: "")
+            }
         } catch {
             return ContributeData(count: 0, weekend: "", date: "")
         }
     }
     
-    private func selectCountFrom(str: String) -> String {
-        let pattern = "\\d+"
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            return "0"
+    private func selectCountFrom(sentence: String) -> Int? {
+        guard let firstVerse = sentence.components(separatedBy: " ").first else {
+            return nil
         }
-        let range = NSRange(location: 0, length: str.utf16.count)
-        if let match = regex.firstMatch(in: str, options: [], range: range) {
-            let value = (str as NSString).substring(with: match.range)
-            return value
+        guard let integerValue = Int(firstVerse) else {
+            return 0
         }
-        return "0"
+        return integerValue
     }
     
     private func parseHtmltoData(html: String) -> [ContributeData] {

--- a/Sources/Consts/ParseKeys.swift
+++ b/Sources/Consts/ParseKeys.swift
@@ -9,6 +9,5 @@ import Foundation
 
 enum ParseKeys {
     static let date = "data-date"
-    static let contributionCount = "data-level"
     static let rect = "rect"
 }


### PR DESCRIPTION
## What does this PR do?
잔디 앱에서 커밋 카운트를 가져오는 방법에 수정을 가했습니다.

## Why are we doing this?
<img width="80%" alt="스크린샷 2023-01-10 오후 2 59 02" src="https://user-images.githubusercontent.com/54518925/211472990-b14cfa31-d3a5-4d8f-8f6f-0859c0a8014f.png">

현재 코드대로 커밋을 가져올 경우 유저의 커밋 카운트가 아닌 다른 숫자를 참조하여 커밋을 가져오게 됩니다. 따라서 html element 내의 text를 파싱해서 가장 앞에 오는 문자열을 정수로 바꿔서 가져오는 로직으로 커밋 카운트를 가져오는 방식을 개선했습니다.