### PR TITLE
🚑 Change Countribution parse logic

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -530,11 +530,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         do {
             let doc: Document = try SwiftSoup.parse(html)
             let rects: Elements = try doc.getElementsByTag(ParseKeys.rect)
+            let tooltips: Elements = try doc.getElementsByTag(ParseKeys.tooltip)
             let days: [Element] = rects.array().filter { $0.hasAttr(ParseKeys.date) }
             let sortedDays = sortDaysByDate(days, with: isoDateFormatter)
-
+            
             let weekend = sortedDays.suffix(Consts.fetchCount)
-            let contributeDataList = weekend.map(mapFunction)
+            
+            var tooltipsTextById = [String: String]()
+            for tooltip in tooltips.array() {
+                let id = try tooltip.attr("for")
+                let text = try tooltip.text()
+                tooltipsTextById[id] = text
+            }
+            
+            let updatedWeekend = weekend.map { element -> Element in
+                
+                let id = element.id()
+                if let tooltipText = tooltipsTextById[id] {
+                    try? element.text(tooltipText)
+                }
+                return element
+            }
+         
+            let contributeDataList = updatedWeekend.map(mapFunction)
             return contributeDataList
             
         } catch {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -533,7 +533,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let tooltips: Elements = try doc.getElementsByTag(ParseKeys.tooltip)
             let days: [Element] = rects.array().filter { $0.hasAttr(ParseKeys.date) }
             let sortedDays = sortDaysByDate(days, with: isoDateFormatter)
-            
             let weekend = sortedDays.suffix(Consts.fetchCount)
             
             var tooltipsTextById = [String: String]()
@@ -544,7 +543,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             
             let updatedWeekend = weekend.map { element -> Element in
-                
                 let id = element.id()
                 if let tooltipText = tooltipsTextById[id] {
                     try? element.text(tooltipText)

--- a/Sources/Consts/ParseKeys.swift
+++ b/Sources/Consts/ParseKeys.swift
@@ -10,4 +10,5 @@ import Foundation
 enum ParseKeys {
     static let date = "data-date"
     static let rect = "td"
+    static let tooltip = "tool-tip"
 }


### PR DESCRIPTION
## What does this PR do?
#31 에 관련된 이슈를 수정하였습니다. 

<img width="1213" alt="image" src="https://github.com/techinpark/Jandi/assets/45546296/beee03f9-8dad-465e-92b0-3aac6f124290">

기존에는 `td` 에 있는 문구만을 파싱하였지만  `tool-tip` 태그가 추가되어 해당 태그에 있는 문구를 파싱하는 방식으로 변경하였습니다.

Previously, we only parsed the phrase in `td`, but with the addition of the `tool-tip` tag, we changed to parse the text in that tag.